### PR TITLE
Add judge R1 controls, token tooltips, auto-end timer, drawing fixes,…

### DIFF
--- a/public/host/host.js
+++ b/public/host/host.js
@@ -187,6 +187,7 @@ function cacheDomElements() {
     // Game over elements
     dom.gameOverWinner = document.getElementById('gameover-winner-name');
     dom.finalRankings = document.getElementById('final-scoreboard');
+    dom.winningGallery = document.getElementById('winning-gallery');
     dom.playAgainBtn = document.getElementById('play-again-btn');
 
     // Steal modal
@@ -1079,7 +1080,8 @@ function startDrawingPhase(data) {
         // Hide end-drawing button until timer expires
         if (dom.endDrawingBtn) {
             dom.endDrawingBtn.style.display = 'none';
-            dom.endDrawingBtn.disabled = true;
+            dom.endDrawingBtn.disabled = false;
+            dom.endDrawingBtn.textContent = "End Drawing - Start Judging";
         }
     } else {
         if (dom.timerText) dom.timerText.textContent = 'No Timer';
@@ -1349,9 +1351,9 @@ function renderTokenAwards() {
                 <button class="token-btn ${isAwarded ? 'unavailable' : ''}"
                         data-player-id="${player.id}"
                         data-token-type="${tokenType}"
-                        ${isAwarded ? 'disabled' : ''}
-                        title="${tokenInfo.description}">
+                        ${isAwarded ? 'disabled' : ''}>
                     ${tokenInfo.icon} ${tokenInfo.name}
+                    <span class="token-tooltip">${tokenInfo.description}</span>
                 </button>
             `;
         });
@@ -1760,7 +1762,7 @@ function buildTokenIcons(tokens) {
     TOKEN_TYPE_KEYS.forEach(key => {
         const count = tokens[key] || 0;
         if (count > 0) {
-            icons += `<span class="token-icon" title="${TOKEN_TYPES[key].name}">${TOKEN_TYPES[key].icon}${count > 1 ? `x${count}` : ''}</span>`;
+            icons += `<span class="token-icon">${TOKEN_TYPES[key].icon}${count > 1 ? `x${count}` : ''}<span class="token-icon-tip">${TOKEN_TYPES[key].name}: ${TOKEN_TYPES[key].description}</span></span>`;
         }
     });
     return icons || '<span class="no-tokens">-</span>';
@@ -1873,9 +1875,46 @@ function showGameOver(data) {
         });
     }
 
+    // Display winning drawings gallery
+    renderWinningGallery(data.winningDrawings || []);
+
     if (dom.playAgainBtn) {
         dom.playAgainBtn.disabled = false;
     }
+}
+
+function renderWinningGallery(drawings) {
+    const gallery = document.getElementById('winning-gallery');
+    if (!gallery) return;
+    gallery.innerHTML = '';
+
+    if (!drawings || drawings.length === 0) {
+        gallery.innerHTML = '<div style="color: #FF69B4; opacity: 0.6; padding: 20px;">No winning drawings to display.</div>';
+        return;
+    }
+
+    drawings.forEach((drawing) => {
+        const card = document.createElement('div');
+        card.classList.add('winning-card');
+
+        const promptText = drawing.prompt ? escapeHtml(drawing.prompt) : '';
+        const alignText = drawing.alignment ? escapeHtml(drawing.alignment) : '';
+
+        card.innerHTML = `
+            <img class="winning-card-img" src="${drawing.drawing}" alt="Winning drawing by ${escapeHtml(drawing.playerName)}" />
+            <div class="winning-card-info">
+                <div class="winning-card-round">Round ${drawing.round}${alignText ? ' \u2022 ' + alignText : ''}</div>
+                <div class="winning-card-player">${drawing.playerAvatar || '\uD83C\uDFA8'} ${escapeHtml(drawing.playerName)}</div>
+                ${promptText ? `<div class="winning-card-prompt">"${promptText}"</div>` : ''}
+            </div>
+        `;
+
+        card.addEventListener('click', () => {
+            openImageLightbox(drawing.drawing, drawing.playerName);
+        });
+
+        gallery.appendChild(card);
+    });
 }
 
 // =============================================================================

--- a/public/host/index.html
+++ b/public/host/index.html
@@ -602,6 +602,29 @@
 
         .token-icon {
             margin-right: 4px;
+            position: relative;
+            cursor: default;
+        }
+
+        .token-icon .token-icon-tip {
+            display: none;
+            position: absolute;
+            bottom: calc(100% + 6px);
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0,0,0,0.95);
+            border: 2px solid #FF69B4;
+            border-radius: 8px;
+            padding: 6px 10px;
+            font-size: 0.85em;
+            color: #FFB6C1;
+            white-space: nowrap;
+            z-index: 100;
+            pointer-events: none;
+        }
+
+        .token-icon:hover .token-icon-tip {
+            display: block;
         }
 
         .no-tokens {
@@ -1042,11 +1065,11 @@
         }
 
         .submission-drawing {
+            position: relative;
             overflow: hidden;
             border-radius: 10px;
             border: 2px solid rgba(255,105,180,0.3);
             background: #fff;
-            max-height: 280px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1055,7 +1078,7 @@
 
         .submission-drawing img {
             max-width: 100%;
-            max-height: 280px;
+            height: auto;
             object-fit: contain;
             display: block;
         }
@@ -1407,10 +1430,11 @@
         }
 
         .curse-target-card {
+            font-family: 'Courier New', monospace;
             background: linear-gradient(135deg, rgba(255,105,180,0.1), rgba(199,21,133,0.05));
             border: 3px solid #FF69B4;
             border-radius: 15px;
-            padding: 15px;
+            padding: 20px;
             text-align: center;
             cursor: pointer;
             transition: all 0.3s ease;
@@ -1429,14 +1453,19 @@
         }
 
         .curse-target-card .target-avatar {
-            font-size: 2em;
-            margin-bottom: 5px;
+            display: block;
+            font-size: 2.5em;
+            margin-bottom: 8px;
         }
 
         .curse-target-card .target-name {
-            font-size: 0.9em;
+            display: block;
+            font-family: 'Courier New', monospace;
+            font-size: 1.1em;
             color: #FFB6C1;
             font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 1px;
         }
 
         .curse-actions {
@@ -1537,6 +1566,92 @@
             font-size: 1.4em;
             font-weight: bold;
             color: #FFD700;
+        }
+
+        /* ================================================================
+           WINNING DRAWINGS GALLERY
+           ================================================================ */
+        .winning-gallery-wrapper {
+            position: relative;
+            overflow: hidden;
+            margin: 20px 0 30px;
+        }
+
+        .winning-gallery {
+            display: flex;
+            gap: 20px;
+            overflow-x: auto;
+            padding: 10px 5px 20px;
+            scroll-behavior: smooth;
+            scroll-snap-type: x mandatory;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .winning-gallery::-webkit-scrollbar {
+            height: 8px;
+        }
+
+        .winning-gallery::-webkit-scrollbar-track {
+            background: rgba(255,105,180,0.1);
+            border-radius: 4px;
+        }
+
+        .winning-gallery::-webkit-scrollbar-thumb {
+            background: #FF69B4;
+            border-radius: 4px;
+        }
+
+        .winning-card {
+            flex: 0 0 280px;
+            scroll-snap-align: center;
+            background: linear-gradient(135deg, rgba(255,105,180,0.1), rgba(199,21,133,0.05));
+            border: 3px solid #FF69B4;
+            border-radius: 15px;
+            padding: 15px;
+            text-align: center;
+            transition: all 0.3s ease;
+        }
+
+        .winning-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 8px 25px rgba(255,105,180,0.4);
+            border-color: #FFD700;
+        }
+
+        .winning-card-img {
+            width: 100%;
+            height: auto;
+            border-radius: 10px;
+            border: 2px solid rgba(255,105,180,0.3);
+            background: #fff;
+            display: block;
+            object-fit: contain;
+        }
+
+        .winning-card-info {
+            margin-top: 10px;
+        }
+
+        .winning-card-round {
+            font-size: 0.75em;
+            color: #FF69B4;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            margin-bottom: 4px;
+        }
+
+        .winning-card-player {
+            font-size: 1em;
+            color: #FFB6C1;
+            font-weight: bold;
+        }
+
+        .winning-card-prompt {
+            font-size: 0.8em;
+            color: #FF69B4;
+            font-style: italic;
+            margin-top: 4px;
+            opacity: 0.8;
         }
 
         /* ================================================================
@@ -2408,6 +2523,13 @@
 
                     <div class="final-scoreboard" id="final-scoreboard">
                         <!-- Final score rows injected by JS -->
+                    </div>
+
+                    <h3 class="section-heading mt-20 mb-10" style="text-align:center;">Winning Drawings</h3>
+                    <div class="winning-gallery-wrapper">
+                        <div class="winning-gallery" id="winning-gallery">
+                            <!-- Winning drawing cards injected by JS -->
+                        </div>
                     </div>
 
                     <div class="center-actions">

--- a/public/player/index.html
+++ b/public/player/index.html
@@ -843,13 +843,14 @@
            SUBMITTED SCREEN
            ================================================================ */
         .submitted-preview {
-            width: 100%;
-            max-width: 280px;
+            max-width: 100%;
+            height: auto;
             margin: 12px auto;
             border-radius: 8px;
             border: 2px solid rgba(255,105,180,0.3);
             background: #fff;
             display: block;
+            object-fit: contain;
         }
 
         /* ================================================================
@@ -1002,21 +1003,21 @@
         }
 
         .modal-title {
-            font-size: 1rem;
+            font-size: 1.3rem;
             font-weight: bold;
             text-transform: uppercase;
-            letter-spacing: 2px;
+            letter-spacing: 3px;
             text-align: center;
             color: #FFD700;
-            margin-bottom: 6px;
+            text-shadow: 0 0 15px rgba(255,215,0,0.4);
+            margin-bottom: 8px;
         }
 
         .modal-subtitle {
             text-align: center;
-            font-size: 0.75rem;
+            font-size: 0.8rem;
             color: #FFB6C1;
             margin-bottom: 16px;
-            opacity: 0.8;
         }
 
         .steal-target-list {
@@ -1028,57 +1029,63 @@
             width: 100%;
             display: flex;
             align-items: center;
-            gap: 12px;
-            padding: 12px 16px;
+            gap: 14px;
+            padding: 14px 18px;
             background: rgba(255,215,0,0.06);
-            border: 1px solid rgba(255,215,0,0.2);
-            border-radius: 10px;
-            margin-bottom: 8px;
+            border: 2px solid rgba(255,215,0,0.3);
+            border-radius: 12px;
+            margin-bottom: 10px;
             cursor: pointer;
             transition: all 0.2s;
             font-family: 'Courier New', monospace;
             color: #FFB6C1;
-            font-size: 0.85rem;
-            min-height: 48px;
+            font-size: 1rem;
+            min-height: 56px;
         }
 
         .steal-target-btn:active {
-            background: rgba(255,215,0,0.15);
+            background: rgba(255,215,0,0.2);
             border-color: #FFD700;
             transform: scale(0.97);
+            box-shadow: 0 0 15px rgba(255,215,0,0.3);
         }
 
         .steal-target-btn .target-avatar {
-            font-size: 1.5rem;
+            font-size: 1.8rem;
         }
 
         .steal-target-btn .target-name {
             flex: 1;
             text-align: left;
+            font-weight: bold;
         }
 
         .steal-target-btn .target-score {
             color: #FFD700;
             font-weight: bold;
+            font-size: 0.9rem;
         }
 
         .modal-cancel {
             width: 100%;
-            padding: 12px;
-            background: transparent;
-            border: 1px solid rgba(255,105,180,0.3);
-            border-radius: 8px;
+            padding: 14px;
+            background: rgba(255,105,180,0.1);
+            border: 2px solid rgba(255,105,180,0.4);
+            border-radius: 10px;
             color: #FF69B4;
             font-family: 'Courier New', monospace;
-            font-size: 0.75rem;
+            font-size: 0.85rem;
+            font-weight: bold;
             text-transform: uppercase;
             letter-spacing: 2px;
             cursor: pointer;
-            min-height: 44px;
+            min-height: 48px;
+            transition: all 0.2s;
         }
 
         .modal-cancel:active {
-            background: rgba(255,105,180,0.1);
+            background: rgba(255,105,180,0.25);
+            transform: scale(0.97);
         }
 
         /* ================================================================
@@ -1190,12 +1197,14 @@
         }
 
         .judge-sub-card img {
-            width: 100%;
-            max-height: 220px;
+            max-width: 100%;
+            height: auto;
+            max-height: 300px;
             object-fit: contain;
             border-radius: 8px;
             background: #fff;
             display: block;
+            margin: 0 auto;
         }
 
         .judge-sub-card .sub-player-info {
@@ -1876,8 +1885,9 @@
          ================================================================ -->
     <div id="steal-modal">
         <div class="modal-content">
+            <div style="font-size:2.5rem; text-align:center; margin-bottom:8px;">&#x1F480;</div>
             <div class="modal-title">Steal a Point</div>
-            <div class="modal-subtitle">Choose a player to steal from (costs 3 tokens)</div>
+            <div class="modal-subtitle">Spend 3 tokens to steal a point from another player</div>
 
             <ul class="steal-target-list" id="steal-target-list"></ul>
 

--- a/server/game/Room.js
+++ b/server/game/Room.js
@@ -29,6 +29,7 @@ export default class Room {
         this.selectedPrompt = null;
         this.submissions = new Map();
         this.selectedWinner = null;
+        this.winningDrawings = [];
 
         this.availableCards = [];
         this.lastAlignment = null;
@@ -337,6 +338,20 @@ export default class Room {
         const player = this.players.find(p => p.id === playerId);
         if (!player) {
             return { success: false, error: 'Player not found' };
+        }
+
+        // Save the winning drawing for the gallery
+        const submission = this.submissions.get(playerId);
+        if (submission) {
+            this.winningDrawings.push({
+                round: this.currentRound,
+                playerId: player.id,
+                playerName: player.name,
+                playerAvatar: player.avatar,
+                drawing: submission.drawing,
+                prompt: this.selectedPrompt,
+                alignment: this.currentAlignmentFullName || this.currentAlignment
+            });
         }
 
         player.score += 1;


### PR DESCRIPTION
… steal styling, winning gallery

- Fix judge controls not showing in round 1: handleGameState now properly routes to showJudgeRollButton/showJudgeChoiceGrid/showJudgeDrawPrompts based on the current phase, so the judge gets controls on game start
- Add tooltip descriptors for award tokens: hover over token icons in the scoreboard or token award buttons to see name and description
- Fix curse card target buttons: add font-family, increase text size, and use uppercase styling to match game aesthetic
- Auto-end drawing phase when all connected non-judge players have submitted, clearing the timer and moving straight to judging
- Fix drawing aspect ratio: use object-fit: contain and height: auto on submission images to prevent stretching/squeezing
- Style the Steal Point modal on player device: larger buttons, skull icon header, matching font and border treatment
- Fix "Ending..." button stuck state: reset button text and enabled state at the start of each drawing phase, add 5-second safety timeout
- Add scrolling gallery of winning drawings to game over screen: server tracks winning submissions per round and sends them with game:over event, host displays horizontal scrolling gallery with round/prompt/artist info

https://claude.ai/code/session_01BznsF6apYDLC6fD17g5ipy