### PR TITLE
Fix 6 UI issues: canvas stretching, drawing previews, buttons, card f…

### DIFF
--- a/public/host/index.html
+++ b/public/host/index.html
@@ -861,9 +861,7 @@
         }
 
         .prompt-card.dealt {
-            opacity: 1;
-            transform: translate3d(0, 0, 0);
-            animation: deal-card 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+            animation: deal-card 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
         }
 
         .prompt-card.dealt:nth-child(1) { animation-delay: 0.05s; }
@@ -1038,8 +1036,8 @@
 
         .submissions-gallery {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-            gap: 20px;
+            grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+            gap: 25px;
             margin: 20px 0;
         }
 
@@ -2350,7 +2348,7 @@
                     </div>
 
                     <div class="center-actions mt-20">
-                        <button class="btn" id="draw-cards-btn" disabled>Draw Cards</button>
+                        <button class="btn btn-gold" id="draw-cards-btn" disabled>Draw Cards</button>
                     </div>
                 </div>
             </div>
@@ -2370,9 +2368,7 @@
                 </div>
 
                 <div id="prompt-cards-container" class="prompt-cards-container">
-                    <div class="prompt-card" id="prompt-card-0">&nbsp;</div>
-                    <div class="prompt-card" id="prompt-card-1">&nbsp;</div>
-                    <div class="prompt-card" id="prompt-card-2">&nbsp;</div>
+                    <!-- Cards injected by JS when judge draws prompts -->
                 </div>
 
                 <div class="center-actions mt-20">
@@ -2464,7 +2460,7 @@
                 </div>
 
                 <div class="center-actions mt-20">
-                    <button class="btn" id="next-round-btn">Next Round</button>
+                    <button class="btn btn-gold" id="next-round-btn">Next Round</button>
                 </div>
             </div>
 
@@ -2488,7 +2484,7 @@
                     </div>
 
                     <div class="center-actions mb-20">
-                        <button class="btn btn-danger" id="draw-curse-btn">Draw Curse Card</button>
+                        <button class="btn btn-danger" id="draw-curse-btn" style="font-size:1.2em; padding:16px 40px;">Draw Curse Card</button>
                     </div>
 
                     <!-- Curse Card Display -->

--- a/public/player/index.html
+++ b/public/player/index.html
@@ -678,12 +678,15 @@
             border-radius: 8px;
             overflow: hidden;
             border: 2px solid rgba(255,105,180,0.3);
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         #drawing-canvas {
             display: block;
-            width: 100%;
-            height: 100%;
+            max-width: 100%;
+            max-height: 100%;
             background: #fff;
             touch-action: none;
             cursor: crosshair;
@@ -1197,9 +1200,8 @@
         }
 
         .judge-sub-card img {
-            max-width: 100%;
+            width: 100%;
             height: auto;
-            max-height: 300px;
             object-fit: contain;
             border-radius: 8px;
             background: #fff;
@@ -1404,11 +1406,10 @@
         }
 
         .fullscreen-canvas-overlay canvas {
-            width: 100%;
-            height: 100%;
             display: block;
             touch-action: none;
             cursor: crosshair;
+            background: #fff;
         }
 
         .floating-toolbar {
@@ -1615,13 +1616,6 @@
                        spellcheck="false">
             </div>
 
-            <div class="section-label text-center">Choose Your Avatar</div>
-            <div class="avatar-selector">
-                <div class="avatar-arrow" id="avatar-prev">&larr;</div>
-                <div class="avatar-display" id="avatar-display"></div>
-                <div class="avatar-arrow" id="avatar-next">&rarr;</div>
-            </div>
-
             <button class="btn btn-primary" id="join-btn">Join Game</button>
             <div class="error-message" id="join-error"></div>
         </div>
@@ -1634,8 +1628,14 @@
         <div class="screen-inner">
             <div class="title">You're In!</div>
 
+            <div class="section-label text-center">Your Avatar</div>
+            <div class="avatar-selector">
+                <div class="avatar-arrow" id="avatar-prev">&larr;</div>
+                <div class="avatar-display" id="avatar-display"></div>
+                <div class="avatar-arrow" id="avatar-next">&rarr;</div>
+            </div>
+
             <div class="info-box">
-                <div style="font-size:2rem;" id="lobby-player-avatar"></div>
                 <div class="info-value" id="lobby-player-name"></div>
             </div>
 
@@ -1784,7 +1784,7 @@
          6. JUDGING SCREEN
          ================================================================ -->
     <div id="judging-screen" class="screen">
-        <div class="screen-inner text-center">
+        <div class="screen-inner text-center" style="max-width:100%">
             <div class="title" id="judging-title">The Judge is Deciding...</div>
 
             <div class="prompt-display mt-16">
@@ -1874,7 +1874,7 @@
             <div class="disconnect-reason" id="disconnect-reason">Connection lost.</div>
 
             <div class="btn-group">
-                <button class="btn btn-primary" id="rejoin-btn">Rejoin</button>
+                <button class="btn btn-gold" id="rejoin-btn" style="font-size:1.2em; padding:14px 36px;">Reconnect!</button>
                 <button class="btn btn-secondary" id="disconnect-new-game-btn">New Game</button>
             </div>
         </div>

--- a/server/game/Room.js
+++ b/server/game/Room.js
@@ -116,6 +116,21 @@ export default class Room {
         return { success: true };
     }
 
+    setPlayerAvatar(playerId, avatar) {
+        const player = this.players.find(p => p.id === playerId);
+        if (!player) {
+            return { success: false, error: 'Player not found' };
+        }
+        // Check if avatar is already taken by another player
+        const taken = this.players.some(p => p.id !== playerId && p.avatar === avatar);
+        if (taken) {
+            return { success: false, error: 'Avatar already taken' };
+        }
+        player.avatar = avatar;
+        this.lastActivity = Date.now();
+        return { success: true, player };
+    }
+
     setPlayerDisconnected(playerId) {
         const player = this.players.find(p => p.id === playerId);
         if (player) {

--- a/server/index.js
+++ b/server/index.js
@@ -604,6 +604,30 @@ io.on('connection', (socket) => {
     });
 
     /**
+     * player:selectAvatar
+     * A player in the lobby changes their avatar.
+     */
+    socket.on('player:selectAvatar', (data, callback) => {
+        if (typeof callback !== 'function') return;
+        const room = getRoom(socket, callback);
+        if (!room) return;
+
+        const { avatar } = data || {};
+        if (!avatar) {
+            return callback({ success: false, error: 'Avatar is required' });
+        }
+
+        const result = room.setPlayerAvatar(socket.id, avatar);
+        if (result.success) {
+            io.to(room.code).emit('room:playerJoined', {
+                player: result.player,
+                players: room.getPlayersPublicData()
+            });
+        }
+        callback(result);
+    });
+
+    /**
      * player:submitDrawing
      * A player submits their drawing for the current round.
      */


### PR DESCRIPTION
…lash, avatars, reconnect

1. Fix drawing stretching: Use fixed 9:16 (360x640) canvas resolution instead of container-dependent sizing. Fullscreen mode now maintains aspect ratio with letterboxing instead of stretching to fill viewport.

2. Expand drawing previews during voting: Remove max-height constraint on judge submission images, increase host gallery grid minimum to 350px.

3. Ensure game stage buttons are visible: Apply btn-gold styling to Next Round and Draw Cards buttons, enlarge Draw Curse Card button.

4. Fix three-card flash: Use animation-fill-mode 'both' so prompt cards stay hidden during animation delay. Remove static opacity/transform from .dealt class. Remove placeholder cards from HTML.

5. Move avatar selection to lobby: Players join without choosing an avatar (server auto-assigns). Avatar selector now appears in lobby screen with server-validated real-time changes via player:selectAvatar event.

6. Improve reconnection: Auto-detect stored session on page load and attempt reconnection before showing join screen. Renamed button to "Reconnect!" with more prominent gold styling.

https://claude.ai/code/session_01GrMp2tCgFTEsf2XczGDv5C